### PR TITLE
ぐるなび応援口コミAPIでデータを取得できる様に修正。

### DIFF
--- a/watsonrestaurant/src/main/java/script/InsertAreaMasterRecords.java
+++ b/watsonrestaurant/src/main/java/script/InsertAreaMasterRecords.java
@@ -1,0 +1,69 @@
+package script;
+
+import general.APIClient;
+import general.Common;
+import general.DBClient;
+import general.ExecuteQuery;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InsertAreaMasterRecords {
+
+	@SuppressWarnings("unchecked")
+	public static void main(String[] args) throws Exception {
+		// TODO 自動生成されたメソッド・スタブ
+		Common.logging("start", "InsertAreaMasterRecords");
+		DBClient.execute(new ExecuteQuery() {
+			public Object call(Connection connection) throws Exception {
+				// TODO 自動生成されたメソッド・スタブ
+				PreparedStatement statement = connection
+						.prepareStatement("delete from area_master");
+				statement.executeUpdate();
+				return null;
+			}
+		});
+
+		HashMap<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("keyid", Common.prop("gurunavi_apikey"));
+		parameters.put("format", "json");
+
+		final Map<String, Object> response = APIClient.getGuruNaviResponse(
+				"master/AreaSearchAPI/20150630", parameters);
+
+		if (response.get("error") != null) {
+			return;
+		}
+
+		DBClient.execute(new ExecuteQuery() {
+			public Object call(Connection connection) throws Exception {
+				// TODO 自動生成されたメソッド・スタブ
+				PreparedStatement statement = connection
+						.prepareStatement("insert into area_master values (?, ?)");
+
+				List<String> idList = new ArrayList<String>();
+				for (Map<String, Object> area : (List<Map<String, Object>>) response
+						.get("area")) {
+					String id = area.get("area_code").toString();
+					if (idList.contains(id)) {
+						continue;
+					}
+					idList.add(id);
+
+					statement.setString(1, Common.formatAPIResponse(id));
+					statement.setString(2,
+							Common.formatAPIResponse(area.get("area_name")));
+
+					statement.executeUpdate();
+				}
+				return null;
+			}
+		});
+
+		Common.logging("end", "InsertAreaMasterRecords");
+	}
+}

--- a/watsonrestaurant/src/main/java/script/InsertKuchikomiRecords.java
+++ b/watsonrestaurant/src/main/java/script/InsertKuchikomiRecords.java
@@ -2,6 +2,8 @@ package script;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,90 +16,139 @@ import general.ExecuteQuery;
 
 public class InsertKuchikomiRecords {
 
-  @SuppressWarnings("unchecked")
-  public static void main(String[] args) throws Exception {
-    // TODO 自動生成されたメソッド・スタブ
-    Common.logging("start", "InsertKuchikomiRecords");
-    DBClient.execute(new ExecuteQuery() {
-      public Object call(Connection connection) throws Exception {
-        // TODO 自動生成されたメソッド・スタブ
-        PreparedStatement statement = connection.prepareStatement("delete from kuchikomi");
-        statement.executeUpdate();
-        return null;
-      }
-    });
+	@SuppressWarnings("unchecked")
+	public static void main(String[] args) throws Exception {
+		// TODO 自動生成されたメソッド・スタブ
+		Common.logging("start", "InsertKuchikomiRecords");
+		DBClient.execute(new ExecuteQuery() {
+			public Object call(Connection connection) throws Exception {
+				// TODO 自動生成されたメソッド・スタブ
+				PreparedStatement statement = connection
+						.prepareStatement("delete from kuchikomi");
+				statement.executeUpdate();
+				return null;
+			}
+		});
 
-    int offsetPage = 0;
-    while (true) {
-      Thread.sleep(1000);
-      offsetPage++;
+		DBClient.execute(new ExecuteQuery() {
+			public Object call(Connection connection) throws Exception {
+				// TODO 自動生成されたメソッド・スタブ
+				PreparedStatement statement = connection
+						.prepareStatement("select area_name as area_name, area_code as area_code from area_master");
+				ResultSet resultSet = statement.executeQuery();
 
-      HashMap<String, Object> parameters = new HashMap<String, Object>();
-      parameters.put("keyid", Common.prop("gurunavi_apikey"));
-      parameters.put("format", "json");
+				while (resultSet.next()) {
 
-      parameters.put("latitude", Common.prop("gurunavi_req_latitude"));
-      parameters.put("longitude", Common.prop("gurunavi_req_longitude"));
-      parameters.put("range", Common.prop("gurunavi_req_range"));
+					String area = resultSet.getString("area_name");
 
-      parameters.put("hit_per_page", 50);
-      parameters.put("offset_page", offsetPage);
+					int offsetPage = 0;
+					
+					while (true) {
+						Thread.sleep(1000);
+						offsetPage++;
 
-      final Map<String, Object> response = APIClient.getGuruNaviResponse("PhotoSearchAPI/20150630", parameters);
+						HashMap<String, Object> parameters = new HashMap<String, Object>();
+						parameters.put("keyid", Common.prop("gurunavi_apikey"));
+						parameters.put("format", "json");
 
-      if (response.get("gnavi") != null) {
-        break;
-      }
+						parameters.put("latitude",
+								Common.prop("gurunavi_req_latitude"));
+						parameters.put("longitude",
+								Common.prop("gurunavi_req_longitude"));
+						parameters.put("range",
+								Common.prop("gurunavi_req_range"));
 
-      DBClient.execute(new ExecuteQuery() {
-        public Object call(Connection connection) throws Exception {
-          // TODO 自動生成されたメソッド・スタブ
-          PreparedStatement statement = connection
-              .prepareStatement("insert into kuchikomi values (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+						parameters.put("area", area);
 
-          List<String> idList = new ArrayList<String>();
-          int photoCount = 1;
-          while (((Map<String, Object>) response.get("response"))
-              .get(((Integer) photoCount).toString()) != null) {
-            Map<String, Object> photo = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) response
-                .get("response")).get(((Integer) photoCount).toString())).get("photo");
+						parameters.put("hit_per_page", 50);
+						parameters.put("offset_page", offsetPage);
 
-            String voteId = photo.get("vote_id").toString();
-            if (idList.contains(voteId)) {
-              photoCount++;
-              continue;
-            }
-            idList.add(voteId);
+						final Map<String, Object> response = APIClient
+								.getGuruNaviResponse("PhotoSearchAPI/20150630",
+										parameters);
 
-            statement.setString(1, Common.formatAPIResponse(voteId));
-            statement.setString(2, Common.formatAPIResponse(photo.get("shop_id")));
-            statement.setString(3, Common.formatAPIResponse(photo.get("shop_name")));
-            statement.setString(4, Common.formatAPIResponse(photo.get("menu_name")));
-            statement.setString(5, Common.formatAPIResponse(photo.get("comment")));
+						if (response.get("gnavi") != null) {
+							break;
+						}
 
-            statement.setString(6, "");
-            Map<String, Object> imageUrl = (Map<String, Object>) photo.get("image_url");
-            Object[] urls = { imageUrl.get("url_1024"), imageUrl.get("url_320"), imageUrl.get("url_250"),
-                imageUrl.get("url_200") };
-            for (Object url : urls) {
-              if (url != null) {
-                statement.setString(6, Common.formatAPIResponse(url));
-                break;
-              }
-            }
+						DBClient.execute(new ExecuteQuery() {
+							public Object call(Connection connection)
+									throws Exception {
+								// TODO 自動生成されたメソッド・スタブ
+								PreparedStatement statement = connection
+										.prepareStatement("insert into kuchikomi values (?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
-            statement.setDouble(7, Common.parseDouble(photo.get("total_score"), -1));
-            statement.setInt(8, Common.parseInt(photo.get("umaso_count"), -1));
-            statement.setString(9, Common.formatAPIResponse(photo.get("update_date")));
+								List<String> idList = new ArrayList<String>();
+								int photoCount = 1;
+								while (((Map<String, Object>) response
+										.get("response"))
+										.get(((Integer) photoCount).toString()) != null) {
+									Map<String, Object> photo = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) response
+											.get("response"))
+											.get(((Integer) photoCount)
+													.toString())).get("photo");
 
-            statement.executeUpdate();
+									String voteId = photo.get("vote_id")
+											.toString();
+									if (idList.contains(voteId)) {
+										photoCount++;
+										continue;
+									}
+									idList.add(voteId);
 
-            photoCount++;
-          }
-          return null;
-        }
-      });
-    }
-    Common.logging("end", "InsertKuchikomiRecords");
-  }
+									statement.setString(1,
+											Common.formatAPIResponse(voteId));
+									statement.setString(2, Common
+											.formatAPIResponse(photo
+													.get("shop_id")));
+									statement.setString(3, Common
+											.formatAPIResponse(photo
+													.get("shop_name")));
+									statement.setString(4, Common
+											.formatAPIResponse(photo
+													.get("menu_name")));
+									statement.setString(5, Common
+											.formatAPIResponse(photo
+													.get("comment")));
+
+									statement.setString(6, "");
+									Map<String, Object> imageUrl = (Map<String, Object>) photo
+											.get("image_url");
+									Object[] urls = { imageUrl.get("url_1024"),
+											imageUrl.get("url_320"),
+											imageUrl.get("url_250"),
+											imageUrl.get("url_200") };
+									for (Object url : urls) {
+										if (url != null) {
+											statement.setString(6, Common
+													.formatAPIResponse(url));
+											break;
+										}
+									}
+
+									statement.setDouble(7, Common.parseDouble(
+											photo.get("total_score"), -1));
+									statement.setInt(8, Common.parseInt(
+											photo.get("umaso_count"), -1));
+									statement.setString(9, Common
+											.formatAPIResponse(photo
+													.get("update_date")));
+
+									try {
+										statement.executeUpdate();
+									} catch(SQLIntegrityConstraintViolationException e) {}
+									
+
+									photoCount++;
+								}
+								return null;
+							}
+						});
+					}
+				}
+				return null;
+			}
+		});
+		Common.logging("end", "InsertKuchikomiRecords");
+	}
 }

--- a/watsonrestaurant/src/main/java/script/ScriptCaller.java
+++ b/watsonrestaurant/src/main/java/script/ScriptCaller.java
@@ -8,8 +8,9 @@ public class ScriptCaller {
     try {
       Common.logging("start", "ScriptCaller");
 
-      // ぐるなびAPIからレストラン情報・応援口コミ情報をDBに登録
+      // ぐるなびAPIからレストラン情報・エリアマスタ・応援口コミ情報をDBに登録
       // InsertRestaurantRecords.main(args);
+      // InsertAreaMasterRecords.main(args);
       // InsertKuchikomiRecords.main(args);
 
       // DBからRetrieve and Rankのドキュメントデータを生成

--- a/watsonrestaurant/temp/resource/ddl.sql
+++ b/watsonrestaurant/temp/resource/ddl.sql
@@ -114,6 +114,20 @@ CREATE TABLE `restaurant` (
   PRIMARY KEY (`shop_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `area_master`
+--
+
+DROP TABLE IF EXISTS `area_master`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `area_master` (
+  `area_code` varchar(255) NOT NULL,
+  `area_name` text NOT NULL,
+  PRIMARY KEY (`area_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
応援口コミAPIで口コミを取得するには、メニュー名やエリア名など、少なくとも何かしらの分類するクエリが１つ以上、必要。
エリア取得APIで、エリア情報を取得しDBに登録するスクリプトの作成と、
応援口コミを取得するスクリプトは、リクエスト毎にエリア名をクエリに設定して、応援口コミAPIを叩く様に修正。